### PR TITLE
macro to convert port from hardware byte order to network byte order

### DIFF
--- a/todo.asm
+++ b/todo.asm
@@ -33,7 +33,10 @@ main:
 
     funcall2 write_cstr, STDOUT, bind_trace_msg
     mov word [servaddr.sin_family], AF_INET
-    mov word [servaddr.sin_port], 14619
+
+    exchange_word_bytes(6969)
+
+    mov word [servaddr.sin_port], ax
     mov dword [servaddr.sin_addr], INADDR_ANY
     bind [sockfd], servaddr.sin_family, sizeof_servaddr
     cmp rax, 0

--- a/utils.inc
+++ b/utils.inc
@@ -170,3 +170,10 @@ starts_with:
 .yes:
     mov rax, 1
     ret
+
+;exchange bytes in a word
+
+macro exchange_word_bytes word_arg {
+    mov ax, word_arg
+    xchg al, ah
+}


### PR DESCRIPTION
now we can use any port without doing some magic 